### PR TITLE
Remove slug from tags. Replace &amp; in tags's section names

### DIFF
--- a/src/main/scala/com/gu/tagdiffer/Tagdiffer.scala
+++ b/src/main/scala/com/gu/tagdiffer/Tagdiffer.scala
@@ -253,7 +253,7 @@ object TagDiffer extends DatabaseComponent {
   }
 
   // The list of comparators to apply to data
-  val comparators:List[ContentComparator] = List(summaryDiff, flexiNewspaperDuplication, publicationTagDiffs, bookTagDiffs, sectionTagDiffs, setOfDeltas, setOfDeltasWithoutRemappedTags, setOfDeltasWithoutSectionMigrationTags)
+  val comparators:List[ContentComparator] = List(setOfDeltasWithoutSectionMigrationTags)
 
   implicit val ContentCategoryFormats = new Format[Category] {
     def reads(json: JsValue): JsResult[Category] = json match {

--- a/src/main/scala/com/gu/tagdiffer/index/model/Tag.scala
+++ b/src/main/scala/com/gu/tagdiffer/index/model/Tag.scala
@@ -26,12 +26,12 @@ case class Tagging(tag: Tag, isLead: Boolean) {
   def tagId = tag.tagId
   def internalName = tag.internalName
   def externalName = tag.externalName
-  //def slug = tag.slug
   def section = tag.section
 
   override def toString: String =
     s"${tag.tagId} [${tag.internalName}] [${tag.externalName}] "+
-      s"${if (isLead) " LEAD" else ""} ${tag.tagType}${if (!tag.existInR2) " NOR2" else ""}"
+      s"${if (isLead) " LEAD" else ""} ${tag.tagType}${if (!tag.existInR2) " NOR2" else ""}"+
+      s" ${tag.section.toString}"
 
   def setIdToZero = Tagging(tag.copy(tagId=0), isLead)
 }
@@ -40,7 +40,6 @@ case class Tag(tagId: Long,
                tagType: TagType,
                internalName: String,
                externalName: String,
-               //slug: Option[String],
                section: Section,
                existInR2: Boolean)
 
@@ -49,10 +48,9 @@ object Tag {
                      tagType: TagType,
                      internalName: String,
                      externalName: String,
-                     //slug: Option[String],
                      section: Section ) = {
     val exist = R2.cache.isR2Tag(tagId)
 
-    Tag(tagId, tagType, internalName, externalName, /*slug,*/ section, exist)
+    Tag(tagId, tagType, internalName, externalName, section, exist)
   }
 }

--- a/src/main/scala/com/gu/tagdiffer/r2.scala
+++ b/src/main/scala/com/gu/tagdiffer/r2.scala
@@ -15,8 +15,7 @@ case class R2Cache(contentPageId: Map[Long, Long],
 case class R2(tagMapper: Map[Long, R2DbTag], liveCache: R2Cache, draftCache: R2Cache) {
 
   lazy val tagIdToTag = tagMapper.map { case (id, r2Tag) =>
-    id -> Tag(id, r2Tag.tagType, r2Tag.internalName, r2Tag.externalName,
-      /*Some(r2Tag.slug),*/ r2Tag.section, existInR2 = true)
+    id -> Tag(id, r2Tag.tagType, r2Tag.internalName, r2Tag.externalName, r2Tag.section, existInR2 = true)
   }
 
   private def lookupR2Tags(pageId: Long, cache: R2Cache): Option[List[Tagging]] = {
@@ -44,8 +43,6 @@ case class R2(tagMapper: Map[Long, R2DbTag], liveCache: R2Cache, draftCache: R2C
 
   private def lookupR2LastModified(pageId: Long, cache: R2Cache): DateTime = {
     val contentId = cache.contentPageId.get(pageId)
-
-    //val t = contentId.map(key => cache.lastModified.get(key).orElse(None)).getOrElse(None)
 
     val timestamp = contentId.map(c => cache.lastModified.get(c).get).get
 

--- a/src/main/scala/com/gu/tagdiffer/scaladb/FlexiContent.scala
+++ b/src/main/scala/com/gu/tagdiffer/scaladb/FlexiContent.scala
@@ -92,15 +92,19 @@ object FlexiContent {
       }
       val internalName = tag.getAs[String]("internalName").get
       val externalName = tag.getAs[String]("externalName").get
-      //val slug = tag.getAs[String]("slug")
       // Section
       val sectionId = section.getAs[Long]("id").get
-      val sectionName = section.getAs[String]("name").get
+      val mongoSectionName = section.getAs[String]("name").get
+      val sectionName = if (mongoSectionName.contains("&amp;")) {
+        mongoSectionName.replace("&amp;", "&")
+      } else {
+        mongoSectionName
+      }
       val sectionPathPrefix = section.getAs[String]("pathPrefix")
       val sectionSlug= section.getAs[String]("slug").get
       val sec = Section(sectionId, sectionName, sectionPathPrefix, sectionSlug)
 
-      Some(Tagging(Tag.createFromFlex(tagId, tt, internalName, externalName, /*slug,*/ sec), isLead))
+      Some(Tagging(Tag.createFromFlex(tagId, tt, internalName, externalName, sec), isLead))
     }
   }
 }

--- a/src/test/scala/com/gu/tagdiffer/unitTests/DiffFunctionTests.scala
+++ b/src/test/scala/com/gu/tagdiffer/unitTests/DiffFunctionTests.scala
@@ -8,13 +8,13 @@ import org.scalatest.matchers.ShouldMatchers
 
 class DiffFunctionTests extends FeatureSpec with GivenWhenThen with ShouldMatchers{
   val section = Section(8, "test section", Some("testSectionPath"), "section")
-  val mainTag = Tagging(Tag(1, Other, "tag 2", "tag", None,  section, true), false)
-  val leadTag = Tagging(Tag(2, Other, "tag 3", "tag", None, section, true), true)
-  val contributorTag = Tagging(Tag(3, Contributor, "tag 4", "tag", None, section, true), false)
-  val contributorTag2 =Tagging( Tag(4, Contributor, "tag 5", "tag", None, section, true), false)
-  val publicationTag = Tagging(Tag(5, Publication, "tag 6", "tag", None, section, true), false)
-  val bookTag = Tagging(Tag(6, Book, "tag 7", "tag", None, section, true), false)
-  val bookSectionTag = Tagging(Tag(7, BookSection, "tag 8", "tag", None, section, true), false)
+  val mainTag = Tagging(Tag(1, Other, "tag 2", "tag", section, true), false)
+  val leadTag = Tagging(Tag(2, Other, "tag 3", "tag", section, true), true)
+  val contributorTag = Tagging(Tag(3, Contributor, "tag 4", "tag", section, true), false)
+  val contributorTag2 =Tagging( Tag(4, Contributor, "tag 5", "tag", section, true), false)
+  val publicationTag = Tagging(Tag(5, Publication, "tag 6", "tag", section, true), false)
+  val bookTag = Tagging(Tag(6, Book, "tag 7", "tag", section, true), false)
+  val bookSectionTag = Tagging(Tag(7, BookSection, "tag 8", "tag", section, true), false)
   val createTimestamp = new DateTime()
   val lastModified = new DateTime()
 


### PR DESCRIPTION
A bunch of difference between tags are due to the absence of the slug filed in the some flexible-content tags. Other difference are due to a bad formatting of & in flexible-content (affecting only section names).
