### PR TITLE
Al correct content representation

### DIFF
--- a/src/main/scala/com/gu/tagdiffer/index/model/Tag.scala
+++ b/src/main/scala/com/gu/tagdiffer/index/model/Tag.scala
@@ -30,7 +30,7 @@ case class Tagging(tag: Tag, isLead: Boolean) {
 
   override def toString: String =
     s"${tag.tagId} [${tag.internalName}] [${tag.externalName}] "+
-      s"${if (isLead) " LEAD" else ""} ${tag.tagType}${if (!tag.existInR2) " NOR2" else ""}"+
+      s"${if (isLead) " LEAD" else ""} ${tag.tagType}${if (!tag.existInR2.getOrElse(false)) " NOR2" else ""}"+
       s" ${tag.section.toString}"
 
   def setIdToZero = Tagging(tag.copy(tagId=0), isLead)
@@ -41,7 +41,7 @@ case class Tag(tagId: Long,
                internalName: String,
                externalName: String,
                section: Section,
-               existInR2: Boolean)
+               existInR2: Option[Boolean])
 
 object Tag {
   def createFromFlex(tagId: Long,
@@ -51,6 +51,6 @@ object Tag {
                      section: Section ) = {
     val exist = R2.cache.isR2Tag(tagId)
 
-    Tag(tagId, tagType, internalName, externalName, section, exist)
+    Tag(tagId, tagType, internalName, externalName, section, Some(exist))
   }
 }

--- a/src/main/scala/com/gu/tagdiffer/index/model/model.scala
+++ b/src/main/scala/com/gu/tagdiffer/index/model/model.scala
@@ -1,6 +1,6 @@
 package com.gu.tagdiffer.index.model
 
-import com.gu.tagdiffer.R2
+import com.gu.tagdiffer.{TagDiffer, R2}
 import com.gu.tagdiffer.TagDiffer.orderAndNumberDiff
 import org.joda.time.DateTime
 

--- a/src/main/scala/com/gu/tagdiffer/r2.scala
+++ b/src/main/scala/com/gu/tagdiffer/r2.scala
@@ -15,7 +15,7 @@ case class R2Cache(contentPageId: Map[Long, Long],
 case class R2(tagMapper: Map[Long, R2DbTag], liveCache: R2Cache, draftCache: R2Cache) {
 
   lazy val tagIdToTag = tagMapper.map { case (id, r2Tag) =>
-    id -> Tag(id, r2Tag.tagType, r2Tag.internalName, r2Tag.externalName, r2Tag.section, existInR2 = true)
+    id -> Tag(id, r2Tag.tagType, r2Tag.internalName, r2Tag.externalName, r2Tag.section, existInR2 = Some(true))
   }
 
   private def lookupR2Tags(pageId: Long, cache: R2Cache): Option[List[Tagging]] = {

--- a/src/test/scala/com/gu/tagdiffer/unitTests/DiffFunctionTests.scala
+++ b/src/test/scala/com/gu/tagdiffer/unitTests/DiffFunctionTests.scala
@@ -8,13 +8,13 @@ import org.scalatest.matchers.ShouldMatchers
 
 class DiffFunctionTests extends FeatureSpec with GivenWhenThen with ShouldMatchers{
   val section = Section(8, "test section", Some("testSectionPath"), "section")
-  val mainTag = Tagging(Tag(1, Other, "tag 2", "tag", section, true), false)
-  val leadTag = Tagging(Tag(2, Other, "tag 3", "tag", section, true), true)
-  val contributorTag = Tagging(Tag(3, Contributor, "tag 4", "tag", section, true), false)
-  val contributorTag2 =Tagging( Tag(4, Contributor, "tag 5", "tag", section, true), false)
-  val publicationTag = Tagging(Tag(5, Publication, "tag 6", "tag", section, true), false)
-  val bookTag = Tagging(Tag(6, Book, "tag 7", "tag", section, true), false)
-  val bookSectionTag = Tagging(Tag(7, BookSection, "tag 8", "tag", section, true), false)
+  val mainTag = Tagging(Tag(1, Other, "tag 2", "tag", section, Some(true)), false)
+  val leadTag = Tagging(Tag(2, Other, "tag 3", "tag", section, Some(true)), true)
+  val contributorTag = Tagging(Tag(3, Contributor, "tag 4", "tag", section, Some(true)), false)
+  val contributorTag2 =Tagging( Tag(4, Contributor, "tag 5", "tag", section, Some(true)), false)
+  val publicationTag = Tagging(Tag(5, Publication, "tag 6", "tag", section, Some(true)), false)
+  val bookTag = Tagging(Tag(6, Book, "tag 7", "tag", section, Some(true)), false)
+  val bookSectionTag = Tagging(Tag(7, BookSection, "tag 8", "tag", section, Some(true)), false)
   val createTimestamp = new DateTime()
   val lastModified = new DateTime()
 

--- a/src/test/scala/com/gu/tagdiffer/unitTests/DiffFunctionTests.scala
+++ b/src/test/scala/com/gu/tagdiffer/unitTests/DiffFunctionTests.scala
@@ -1,23 +1,12 @@
 package com.gu.tagdiffer.unitTests
 
 import com.gu.tagdiffer.index.model._
-import com.gu.tagdiffer.index.model.TagType._
-import org.joda.time.DateTime
 import org.scalatest.{FeatureSpec, GivenWhenThen}
 import org.scalatest.matchers.ShouldMatchers
+import com.gu.tagdiffer.unitTests.TestTags._
+
 
 class DiffFunctionTests extends FeatureSpec with GivenWhenThen with ShouldMatchers{
-  val section = Section(8, "test section", Some("testSectionPath"), "section")
-  val mainTag = Tagging(Tag(1, Other, "tag 2", "tag", section, Some(true)), false)
-  val leadTag = Tagging(Tag(2, Other, "tag 3", "tag", section, Some(true)), true)
-  val contributorTag = Tagging(Tag(3, Contributor, "tag 4", "tag", section, Some(true)), false)
-  val contributorTag2 =Tagging( Tag(4, Contributor, "tag 5", "tag", section, Some(true)), false)
-  val publicationTag = Tagging(Tag(5, Publication, "tag 6", "tag", section, Some(true)), false)
-  val bookTag = Tagging(Tag(6, Book, "tag 7", "tag", section, Some(true)), false)
-  val bookSectionTag = Tagging(Tag(7, BookSection, "tag 8", "tag", section, Some(true)), false)
-  val createTimestamp = new DateTime()
-  val lastModified = new DateTime()
-
   feature("Check tags order") {
     scenario("different order") {
       given("the same tags")

--- a/src/test/scala/com/gu/tagdiffer/unitTests/TestTags.scala
+++ b/src/test/scala/com/gu/tagdiffer/unitTests/TestTags.scala
@@ -1,0 +1,24 @@
+package com.gu.tagdiffer.unitTests
+
+import com.gu.tagdiffer.index.model.TagType._
+import com.gu.tagdiffer.index.model.{Tag, Tagging, Section}
+import org.joda.time.DateTime
+
+object TestTags {
+  // Create Tags
+  val section = Section(8, "test section", Some("testSectionPath"), "section")
+  val mainTag = Tagging(Tag(1, Other, "tag 1", "tag", section, Some(true)), false)
+  val mainTagRenamed = Tagging(mainTag.tag.copy(internalName = "tag renamed"), false)
+  val oldTag = Tagging(mainTag.tag.copy(existInR2 = Some(false)), false)
+  val newTag = Tagging(oldTag.tag.copy(tagId = 9L, section = section.copy(id = 9L)), false)
+  val leadTag = Tagging(Tag(2, Other, "tag 2", "tag", section, Some(true)), true)
+  val noLeadTag = leadTag.copy(isLead = false)
+  val contributorTag = Tagging(Tag(3, Contributor, "tag 3", "tag", section, Some(true)), false)
+  val contributorTag2 = Tagging(Tag(4, Contributor, "tag 4", "tag", section, Some(true)), false)
+  val publicationTag = Tagging(Tag(5, Publication, "tag 5", "tag", section, Some(true)), false)
+  val publicationTag2 = Tagging(Tag(6, Publication, "tag 6", "tag", section, Some(true)), false)
+  val bookTag = Tagging(Tag(7, Book, "tag 7", "tag", section, Some(true)), false)
+  val bookSectionTag = Tagging(Tag(8, BookSection, "tag 8", "tag", section, Some(true)), false)
+  val createTimestamp = new DateTime()
+  val lastModified = new DateTime()
+}

--- a/src/test/scala/com/gu/tagdiffer/unitTests/jsonMappingTest.scala
+++ b/src/test/scala/com/gu/tagdiffer/unitTests/jsonMappingTest.scala
@@ -1,13 +1,11 @@
 package com.gu.tagdiffer.unitTests
 
 import com.gu.tagdiffer.TagDiffer
-import com.gu.tagdiffer.index.model
 import com.gu.tagdiffer.index.model.TagType._
 import com.gu.tagdiffer.index.model._
 import org.joda.time.DateTime
 import org.scalatest.{FeatureSpec, GivenWhenThen}
 import org.scalatest.matchers.ShouldMatchers
-import play.api.data.validation.ValidationError
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 
@@ -15,11 +13,11 @@ case class TagMapping (pageId: String,
                        contentId: ContentId,
                        lastModifiedFlexi: DateTime,
                        lastModifiedR2: DateTime,
-                        tags: List[Tagging],
-                        contributors: List[Tagging],
-                        publication: Tagging,
-                        book: Tagging,
-                        bookSection: Tagging)
+                       tags: List[Tagging],
+                       contributors: List[Tagging],
+                       publication: Tagging,
+                       book: Tagging,
+                       bookSection: Tagging)
 
 object EnumUtils {
   def enumReads[E <: Enumeration](enum: E): Reads[E#Value] = new Reads[E#Value] {
@@ -39,24 +37,27 @@ object EnumUtils {
 class jsonMappingTest extends FeatureSpec with GivenWhenThen with ShouldMatchers {
   // Create Tags
   val section = Section(8, "test section", Some("testSectionPath"), "section")
-  val mainTag = Tagging(Tag(1, Other, "tag 2", "tag", section, Some(true)), false)
-  val leadTag = Tagging(Tag(2, Other, "tag 3", "tag", section, Some(true)), true)
-  val noLeadTag = Tagging(Tag(2, Other, "tag 3", "tag", section, Some(true)), false)
-  val contributorTag = Tagging(Tag(3, Contributor, "tag 4", "tag", section, Some(true)), false)
-  val contributorTag2 =Tagging( Tag(4, Contributor, "tag 5", "tag", section, Some(true)), false)
-  val publicationTag = Tagging(Tag(5, Publication, "tag 6", "tag", section, Some(true)), false)
-  val bookTag = Tagging(Tag(6, Book, "tag 7", "tag", section, Some(true)), false)
-  val bookSectionTag = Tagging(Tag(7, BookSection, "tag 8", "tag", section, Some(true)), false)
+  val mainTag = Tagging(Tag(1, Other, "tag 1", "tag", section, Some(true)), false)
+  val mainTagRenamed = Tagging(mainTag.tag.copy(internalName = "tag renamed"), false)
+  val oldTag = Tagging(mainTag.tag.copy(existInR2 = Some(false)), false)
+  val newTag = Tagging(oldTag.tag.copy(tagId = 9L, section = section.copy(id = 9L)), false)
+  val leadTag = Tagging(Tag(2, Other, "tag 2", "tag", section, Some(true)), true)
+  val noLeadTag = leadTag.copy(isLead = false)
+  val contributorTag = Tagging(Tag(3, Contributor, "tag 3", "tag", section, Some(true)), false)
+  val contributorTag2 = Tagging(Tag(4, Contributor, "tag 4", "tag", section, Some(true)), false)
+  val publicationTag = Tagging(Tag(5, Publication, "tag 5", "tag", section, Some(true)), false)
+  val publicationTag2 = Tagging(Tag(6, Publication, "tag 6", "tag", section, Some(true)), false)
+  val bookTag = Tagging(Tag(7, Book, "tag 7", "tag", section, Some(true)), false)
+  val bookSectionTag = Tagging(Tag(8, BookSection, "tag 8", "tag", section, Some(true)), false)
   val createTimestamp = new DateTime()
   val lastModified = new DateTime()
 
   // init tag migration tag
-  TagDiffer.tagMigrationCache = Map.empty[Long, Tagging]
+  TagDiffer.tagMigrationCache = Map(oldTag.tagId -> newTag)
 
-  // read json
+  // JSON Reads and Format
   implicit val SectionFormats = TagDiffer.SectionFormats
   implicit val TagTypeFormat: Reads[TagType.Value] = EnumUtils.enumReads(TagType)
-
   implicit val TagFormats: Reads[Tag] = (
     (__ \ "tagId").read[Long] and
       (__ \ "tagType").read[TagType] and
@@ -64,8 +65,7 @@ class jsonMappingTest extends FeatureSpec with GivenWhenThen with ShouldMatchers
       (__ \ "externalName").read[String] and
       (__ \ "section").read[Section] and
       (__ \ "existInR2").readNullable[Boolean]
-    ) (Tag.apply _)
-
+    )(Tag.apply _)
   implicit val TaggingFormats = TagDiffer.TaggingFormats
   implicit val TagMappingReader: Reads[TagMapping] = (
     (__ \ "pageId").read[String] and
@@ -77,30 +77,180 @@ class jsonMappingTest extends FeatureSpec with GivenWhenThen with ShouldMatchers
       (__ \ "taxonomy" \ "publication").read[Tagging] and
       (__ \ "taxonomy" \ "newspaper" \ "book").read[Tagging] and
       (__ \ "taxonomy" \ "newspaper" \ "bookSection").read[Tagging]
-    ) (TagMapping.apply _)
+    )(TagMapping.apply _)
 
-  feature("The json has the valid structure") {
-    scenario ("differences exist"){
-      val flexiTags = FlexiTags(List(leadTag), List(contributorTag), List(publicationTag), List(bookTag), List(bookSectionTag))
-      val r2Tags = R2Tags(List(mainTag, leadTag,  contributorTag, publicationTag, bookTag, bookSectionTag))
+  feature("The json format is valid") {
+    scenario("differences exist") {
+      val flexiTags = FlexiTags(List(leadTag, newTag), List(contributorTag), List(publicationTag), List(bookTag), List(bookSectionTag))
+      val r2Tags = R2Tags(List(leadTag, mainTag, contributorTag, publicationTag, bookTag, bookSectionTag))
       val content = Content("1", "11", "article", createTimestamp, lastModified, lastModified, flexiTags, r2Tags)
 
       val jsonMapping = TagDiffer.correctFlexiRepresentation(List[Content](content)).head
-      then("the json of tag mapping should be the one expected")
+      then("the json should be the one expected")
       val res = jsonMapping.validate[TagMapping]
-
       res.isSuccess should be(true)
+      and("each json path contains the expected tagType")
+      val mapping = res.get
+      val isTagTypeCorrect = (mapping.book.tagType == Book) && (mapping.bookSection.tagType == BookSection) &&
+        (mapping.contributors.forall(_.tagType == Contributor)) && (mapping.publication.tagType == Publication) &&
+        (mapping.tags.forall(_.tagType == Other))
+      isTagTypeCorrect should be(true)
+      and ("the original order of main tags is preserved with diff tags added at the bottom")
+      val mainTags = (mapping.tags.head.tagId == leadTag.tagId) && (mapping.tags.last.tagId == mainTag.tagId)
     }
 
-    scenario ("difference do not exists"){
+    scenario("differences do not exist") {
       val flexiTags = FlexiTags(List(mainTag, leadTag), List(contributorTag), List(publicationTag), List(bookTag), List(bookSectionTag))
-      val r2Tags = R2Tags(List(mainTag, leadTag,  contributorTag, publicationTag, bookTag, bookSectionTag))
+      val r2Tags = R2Tags(List(mainTag, leadTag, contributorTag, publicationTag, bookTag, bookSectionTag))
       val content = Content("1", "11", "article", createTimestamp, lastModified, lastModified, flexiTags, r2Tags)
 
       val jsonMapping = TagDiffer.correctFlexiRepresentation(List[Content](content))
-      then("the list of tag mapping json should be empty")
+      then("the list of json should be empty")
       jsonMapping.isEmpty should be(true)
     }
   }
 
+  feature("Newspaper tag duplication") {
+    scenario("Flexible-content has differences and duplicated newspaper tags ") {
+      val flexiTags = FlexiTags(List(leadTag, bookTag, bookSectionTag), List(contributorTag), List(publicationTag), List(bookTag), List(bookSectionTag))
+      val r2Tags = R2Tags(List(mainTag, leadTag, contributorTag, publicationTag, bookTag, bookSectionTag))
+      val content = Content("1", "11", "article", createTimestamp, lastModified, lastModified, flexiTags, r2Tags)
+
+      val jsonMapping = TagDiffer.correctFlexiRepresentation(List[Content](content)).head
+      val res = jsonMapping.validate[TagMapping].get
+      val mainTags = res.tags.forall(t => (t.tagType != Book) && (t.tagType != BookSection)) &&
+        res.tags.filter(_.tagId == mainTag.tagId).nonEmpty
+      val newspaperTags = (res.book.tagId == bookTag.tagId) && (res.bookSection.tagId == bookSectionTag.tagId)
+      then("newspaper tag should not appear in main tag list")
+      mainTags should be(true)
+      and("should only be in the newspaper section")
+      newspaperTags should be(true)
+    }
+
+    scenario("Flexible-content has only duplicated newspaper tags ") {
+      val flexiTags = FlexiTags(List(leadTag, bookTag, bookSectionTag), List(contributorTag), List(publicationTag), List(bookTag), List(bookSectionTag))
+      val r2Tags = R2Tags(List(leadTag, contributorTag, publicationTag, bookTag, bookSectionTag))
+      val content = Content("1", "11", "article", createTimestamp, lastModified, lastModified, flexiTags, r2Tags)
+
+      val jsonMapping = TagDiffer.correctFlexiRepresentation(List[Content](content)).head
+      val res = jsonMapping.validate[TagMapping].get
+      val mainTags = res.tags.forall(t => (t.tagType != Book) && (t.tagType != BookSection))
+      val newspaperTags = (res.book.tagId == bookTag.tagId) && (res.bookSection.tagId == bookSectionTag.tagId)
+      then("newspaper tag should not appear in main tag list")
+      mainTags should be(true)
+      and("should only be in the newspaper section")
+      newspaperTags should be(true)
+    }
+  }
+
+  feature("Contributor tag discrepancy") {
+    scenario("Flexible-content has no contributor tag") {
+      val flexiTags = FlexiTags(List(leadTag), List(), List(publicationTag), List(bookTag), List(bookSectionTag))
+      val r2Tags = R2Tags(List(leadTag, contributorTag, publicationTag, bookTag, bookSectionTag))
+      val content = Content("1", "11", "article", createTimestamp, lastModified, lastModified, flexiTags, r2Tags)
+
+      val jsonMapping = TagDiffer.correctFlexiRepresentation(List[Content](content)).head
+      val res = jsonMapping.validate[TagMapping].get
+      val contributor = (res.contributors.length == 1) && (res.contributors.head.tagId == contributorTag.tagId)
+      then("the R2 contributor tag is the new contributor tag")
+      contributor should be(true)
+    }
+
+    scenario("Flexible-content have different contributor tags") {
+      val flexiTags = FlexiTags(List(leadTag), List(contributorTag), List(publicationTag), List(bookTag), List(bookSectionTag))
+      val r2Tags = R2Tags(List(leadTag, contributorTag2, publicationTag, bookTag, bookSectionTag))
+      val content = Content("1", "11", "article", createTimestamp, lastModified, lastModified, flexiTags, r2Tags)
+
+      val jsonMapping = TagDiffer.correctFlexiRepresentation(List[Content](content)).head
+      val res = jsonMapping.validate[TagMapping].get
+      val contributor = (res.contributors.length == 2) && (res.contributors.head.tagId == contributorTag.tagId) &&
+        (res.contributors.last.tagId == contributorTag2.tagId)
+      then("the R2 contributor tag is added at the bottom of the contributor tag list")
+      contributor should be(true)
+    }
+  }
+
+  feature("R2 has multiple publication tags") {
+    scenario("Flexible-content has no publication tag") {
+      val flexiTags = FlexiTags(List(leadTag), List(contributorTag), List(), List(bookTag), List(bookSectionTag))
+      val r2Tags = R2Tags(List(leadTag, contributorTag, publicationTag, publicationTag2, bookTag, bookSectionTag))
+      val content = Content("1", "11", "article", createTimestamp, lastModified, lastModified, flexiTags, r2Tags)
+
+      val jsonMapping = TagDiffer.correctFlexiRepresentation(List[Content](content)).head
+      val res = jsonMapping.validate[TagMapping].get
+      val mainTags = res.tags.filter(_.tagId == publicationTag2.tagId).nonEmpty
+      val publication = (res.publication.tagId == publicationTag.tagId)
+      then("the extra publication tag is included in the main tags")
+      mainTags should be(true)
+      and("the first R2 publication shared tag is the publication tag")
+      publication should be(true)
+    }
+
+    scenario("One is shared with flexible content") {
+      val flexiTags = FlexiTags(List(leadTag), List(contributorTag), List(publicationTag), List(bookTag), List(bookSectionTag))
+      val r2Tags = R2Tags(List(leadTag, contributorTag, publicationTag, publicationTag2, bookTag, bookSectionTag))
+      val content = Content("1", "11", "article", createTimestamp, lastModified, lastModified, flexiTags, r2Tags)
+
+      val jsonMapping = TagDiffer.correctFlexiRepresentation(List[Content](content)).head
+      val res = jsonMapping.validate[TagMapping].get
+      val mainTags = res.tags.filter(_.tagId == publicationTag2.tagId).nonEmpty
+      val publication = (res.publication.tagId == publicationTag.tagId)
+      then("the extras publication tags are included in the main tags")
+      mainTags should be(true)
+      and("the shared tag is the publicatio tag")
+      publication should be(true)
+    }
+  }
+
+  feature("Lead tag discrepancy") {
+    scenario("Missing Lead tag in R2") {
+      val flexiTags = FlexiTags(List(leadTag), List(contributorTag), List(publicationTag), List(bookTag), List(bookSectionTag))
+      val r2Tags = R2Tags(List(noLeadTag, contributorTag, publicationTag, bookTag, bookSectionTag))
+      val content = Content("1", "11", "article", createTimestamp, lastModified, lastModified, flexiTags, r2Tags)
+
+      val jsonMapping = TagDiffer.correctFlexiRepresentation(List[Content](content)).head
+      val res = jsonMapping.validate[TagMapping].get
+      val leadtag = (res.tags.length == 1) && res.tags.head.isLead
+      then("the main tags contains the lead tag")
+      leadtag should be(true)
+    }
+
+    scenario("Missing Lead tag in flexible-content") {
+      val flexiTags = FlexiTags(List(noLeadTag), List(contributorTag), List(publicationTag), List(bookTag), List(bookSectionTag))
+      val r2Tags = R2Tags(List(leadTag, contributorTag, publicationTag, bookTag, bookSectionTag))
+      val content = Content("1", "11", "article", createTimestamp, lastModified, lastModified, flexiTags, r2Tags)
+
+      val jsonMapping = TagDiffer.correctFlexiRepresentation(List[Content](content)).head
+      val res = jsonMapping.validate[TagMapping].get
+      val leadtag = (res.tags.length == 1) && res.tags.head.isLead
+      then("the main tags contains the lead tag")
+      leadtag should be(true)
+    }
+  }
+
+  feature("Tag renaming/migration") {
+    scenario("The tag has been renamed but keeps the same ID") {
+      val flexiTags = FlexiTags(List(mainTag), List(contributorTag), List(publicationTag), List(bookTag), List(bookSectionTag))
+      val r2Tags = R2Tags(List(mainTagRenamed, contributorTag, publicationTag, bookTag, bookSectionTag))
+      val content = Content("1", "11", "article", createTimestamp, lastModified, lastModified, flexiTags, r2Tags)
+
+      val jsonMapping = TagDiffer.correctFlexiRepresentation(List[Content](content)).head
+      val res = jsonMapping.validate[TagMapping].get
+      val renamed = (res.tags.length == 1) && (res.tags.head.internalName == mainTagRenamed.internalName)
+      then("the tag has the correct name")
+      renamed should be(true)
+    }
+
+    scenario("Only the tag ID has changed after section migration") {
+      val flexiTags = FlexiTags(List(oldTag), List(contributorTag), List(publicationTag), List(bookTag), List(bookSectionTag))
+      val r2Tags = R2Tags(List(newTag, contributorTag, publicationTag, bookTag, bookSectionTag))
+      val content = Content("1", "11", "article", createTimestamp, lastModified, lastModified, flexiTags, r2Tags)
+
+      val jsonMapping = TagDiffer.correctFlexiRepresentation(List[Content](content)).head
+      val res = jsonMapping.validate[TagMapping].get
+      val migrated = (res.tags.length == 1) && (res.tags.head.tagId == newTag.tagId)
+      then("the tag has the correct ID")
+      migrated should be(true)
+    }
+  }
 }

--- a/src/test/scala/com/gu/tagdiffer/unitTests/jsonMappingTest.scala
+++ b/src/test/scala/com/gu/tagdiffer/unitTests/jsonMappingTest.scala
@@ -1,0 +1,106 @@
+package com.gu.tagdiffer.unitTests
+
+import com.gu.tagdiffer.TagDiffer
+import com.gu.tagdiffer.index.model
+import com.gu.tagdiffer.index.model.TagType._
+import com.gu.tagdiffer.index.model._
+import org.joda.time.DateTime
+import org.scalatest.{FeatureSpec, GivenWhenThen}
+import org.scalatest.matchers.ShouldMatchers
+import play.api.data.validation.ValidationError
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+
+case class TagMapping (pageId: String,
+                       contentId: ContentId,
+                       lastModifiedFlexi: DateTime,
+                       lastModifiedR2: DateTime,
+                        tags: List[Tagging],
+                        contributors: List[Tagging],
+                        publication: Tagging,
+                        book: Tagging,
+                        bookSection: Tagging)
+
+object EnumUtils {
+  def enumReads[E <: Enumeration](enum: E): Reads[E#Value] = new Reads[E#Value] {
+    def reads(json: JsValue): JsResult[E#Value] = json match {
+      case JsString(s) => {
+        try {
+          JsSuccess(enum.withName(s))
+        } catch {
+          case _: NoSuchElementException => JsError(s"Enumeration expected of type: '${enum.getClass}', but it does not appear to contain the value: '$s'")
+        }
+      }
+      case _ => JsError("String value expected")
+    }
+  }
+}
+
+class jsonMappingTest extends FeatureSpec with GivenWhenThen with ShouldMatchers {
+  // Create Tags
+  val section = Section(8, "test section", Some("testSectionPath"), "section")
+  val mainTag = Tagging(Tag(1, Other, "tag 2", "tag", section, Some(true)), false)
+  val leadTag = Tagging(Tag(2, Other, "tag 3", "tag", section, Some(true)), true)
+  val noLeadTag = Tagging(Tag(2, Other, "tag 3", "tag", section, Some(true)), false)
+  val contributorTag = Tagging(Tag(3, Contributor, "tag 4", "tag", section, Some(true)), false)
+  val contributorTag2 =Tagging( Tag(4, Contributor, "tag 5", "tag", section, Some(true)), false)
+  val publicationTag = Tagging(Tag(5, Publication, "tag 6", "tag", section, Some(true)), false)
+  val bookTag = Tagging(Tag(6, Book, "tag 7", "tag", section, Some(true)), false)
+  val bookSectionTag = Tagging(Tag(7, BookSection, "tag 8", "tag", section, Some(true)), false)
+  val createTimestamp = new DateTime()
+  val lastModified = new DateTime()
+
+  // init tag migration tag
+  TagDiffer.tagMigrationCache = Map.empty[Long, Tagging]
+
+  // read json
+  implicit val SectionFormats = TagDiffer.SectionFormats
+  implicit val TagTypeFormat: Reads[TagType.Value] = EnumUtils.enumReads(TagType)
+
+  implicit val TagFormats: Reads[Tag] = (
+    (__ \ "tagId").read[Long] and
+      (__ \ "tagType").read[TagType] and
+      (__ \ "internalName").read[String] and
+      (__ \ "externalName").read[String] and
+      (__ \ "section").read[Section] and
+      (__ \ "existInR2").readNullable[Boolean]
+    ) (Tag.apply _)
+
+  implicit val TaggingFormats = TagDiffer.TaggingFormats
+  implicit val TagMappingReader: Reads[TagMapping] = (
+    (__ \ "pageId").read[String] and
+      (__ \ "contentId").read[ContentId] and
+      (__ \ "lastModifiedFlexi").read[DateTime] and
+      (__ \ "lastModifiedR2").read[DateTime] and
+      (__ \ "taxonomy" \\ "tags").read[List[Tagging]] and
+      (__ \ "taxonomy" \\ "contributors").read[List[Tagging]] and
+      (__ \ "taxonomy" \ "publication").read[Tagging] and
+      (__ \ "taxonomy" \ "newspaper" \ "book").read[Tagging] and
+      (__ \ "taxonomy" \ "newspaper" \ "bookSection").read[Tagging]
+    ) (TagMapping.apply _)
+
+  feature("The json has the valid structure") {
+    scenario ("differences exist"){
+      val flexiTags = FlexiTags(List(leadTag), List(contributorTag), List(publicationTag), List(bookTag), List(bookSectionTag))
+      val r2Tags = R2Tags(List(mainTag, leadTag,  contributorTag, publicationTag, bookTag, bookSectionTag))
+      val content = Content("1", "11", "article", createTimestamp, lastModified, lastModified, flexiTags, r2Tags)
+
+      val jsonMapping = TagDiffer.correctFlexiRepresentation(List[Content](content)).head
+      then("the json of tag mapping should be the one expected")
+      val res = jsonMapping.validate[TagMapping]
+
+      res.isSuccess should be(true)
+    }
+
+    scenario ("difference do not exists"){
+      val flexiTags = FlexiTags(List(mainTag, leadTag), List(contributorTag), List(publicationTag), List(bookTag), List(bookSectionTag))
+      val r2Tags = R2Tags(List(mainTag, leadTag,  contributorTag, publicationTag, bookTag, bookSectionTag))
+      val content = Content("1", "11", "article", createTimestamp, lastModified, lastModified, flexiTags, r2Tags)
+
+      val jsonMapping = TagDiffer.correctFlexiRepresentation(List[Content](content))
+      then("the list of tag mapping json should be empty")
+      jsonMapping.isEmpty should be(true)
+    }
+  }
+
+}

--- a/src/test/scala/com/gu/tagdiffer/unitTests/jsonMappingTest.scala
+++ b/src/test/scala/com/gu/tagdiffer/unitTests/jsonMappingTest.scala
@@ -51,7 +51,10 @@ class JsonMappingTest extends FeatureSpec with GivenWhenThen with ShouldMatchers
       (__ \ "section").read[Section] and
       (__ \ "existInR2").readNullable[Boolean]
     )(Tag.apply _)
-  implicit val TaggingFormats = TagDiffer.TaggingFormats
+  implicit val TaggingFormats: Reads[Tagging] = (
+    (__ \ "tag").read[Tag] and
+      (__ \ "isLead").readNullable[Boolean].map(_.getOrElse(false))
+    )(Tagging.apply _)
   implicit val TagMappingReader: Reads[TagMapping] = (
     (__ \ "pageId").read[String] and
       (__ \ "contentId").read[ContentId] and


### PR DESCRIPTION
This PR adds the algorithm to fix the discrepancies between flexible-content and R2. It takes into account the problems found in the [preliminary analysis] (https://docs.google.com/a/guardian.co.uk/document/d/1xWLYciP29RW38CTURgyz3NHR2X5yTsx-yCLWkZkZw2Q/edit#). Unit tests are designed around this analysis.
The algorithm output is a list of JSON representing the correct tag mapping plus information on the content.

<b>HOW TO TEST</b>
run unit tests!