### PR TITLE
Al remove global tag migration cache

### DIFF
--- a/src/main/scala/com/gu/tagdiffer/Tagdiffer.scala
+++ b/src/main/scala/com/gu/tagdiffer/Tagdiffer.scala
@@ -561,7 +561,8 @@ object TagDiffer extends DatabaseComponent {
 
       jsonComparators.foreach{ comparator =>
         try{
-          comparator.compare(data, oldToNewTagIdMap).foreach {
+          val ret = comparator.compare(data, oldToNewTagIdMap)
+            ret.foreach {
             case JSONFileResult(fileName, jsons) =>
               val writer = new PrintWriter(s"$PREFIX/$fileName")
               jsons.foreach(json => writer.println(json.toString()))

--- a/src/main/scala/com/gu/tagdiffer/Tagdiffer.scala
+++ b/src/main/scala/com/gu/tagdiffer/Tagdiffer.scala
@@ -561,8 +561,7 @@ object TagDiffer extends DatabaseComponent {
 
       jsonComparators.foreach{ comparator =>
         try{
-          val ret = comparator.compare(data, oldToNewTagIdMap)
-            ret.foreach {
+          comparator.compare(data, oldToNewTagIdMap).foreach {
             case JSONFileResult(fileName, jsons) =>
               val writer = new PrintWriter(s"$PREFIX/$fileName")
               jsons.foreach(json => writer.println(json.toString()))


### PR DESCRIPTION
This PR removes the use of global cache to map tags with migrated section. Moreover it refactors the <code>ContentComparator</code> and <code>ComparatorResult</code> to allow producing different type of objects as output.